### PR TITLE
fix: null error if no rootIsolator on the context

### DIFF
--- a/src/component-mixin.js
+++ b/src/component-mixin.js
@@ -57,10 +57,10 @@ module.exports = {
     // else check if local isolator that we need to
     // release.
     if(!this._owner) {
-      console.log('release rootIsolator');
-      this.context.rootIsolator.release();
+      if(this.context && this.context.rootIsolator) {
+        this.context.rootIsolator.release();
+      }
     } else if(this._$isolator) {
-      console.log('release local isolator');
       this._$isolator.release();
     }
   },


### PR DESCRIPTION
When calling unmountComponentAtNode directly to support using Pixastic, this was throwing an error because there was no rootIsolator. Not sure why it doesn't have a this._owner and does not have a rootIsolator, but this null check fixes the issue.